### PR TITLE
Applying high precision in regl-error2d fragment shader

### DIFF
--- a/index.js
+++ b/index.js
@@ -171,7 +171,7 @@ function Error2D (regl, options) {
 		`,
 
 		frag: `
-		precision mediump float;
+		precision highp float;
 
 		varying vec4 fragColor;
 


### PR DESCRIPTION
It is noticed on `other` gl-vis modules (e.g. https://github.com/plotly/plotly.js/pull/3676) that some graphs were not rendered properly on iOS devices when the `highp` flag is not applied. 
@dy Could we enable high precision in fragment shader here to be consistent with the vertex shader?
cc: @etpinard 

   