### PR TITLE
bump bubleify v2 - regl-error2d module

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/dy/regl-error2d#readme",
   "dependencies": {
     "array-bounds": "^1.0.1",
-    "bubleify": "^1.2.0",
+    "bubleify": "^2.0.0",
     "color-normalize": "^1.5.0",
     "flatten-vertex-data": "^1.0.2",
     "object-assign": "^4.1.1",


### PR DESCRIPTION
Follow up of https://github.com/garthenweb/bubleify/pull/18 now that bubleify v2 is out.
@alexcjohnson @dy 