### PR TITLE
Bump to-float32 package

### DIFF
--- a/index.js
+++ b/index.js
@@ -505,8 +505,10 @@ function Error2D (regl, options) {
 				positionData.set(positions, offset * 2)
 			})
 
-			positionBuffer(float32(positionData))
-			positionFractBuffer(fract32(positionData))
+			var float_data = float32(positionData)
+			positionBuffer(float_data)
+			var frac_data = fract32(positionData, float_data)
+			positionFractBuffer(frac_data)
 			colorBuffer(colorData)
 			errorBuffer(errorData)
 		}

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "flatten-vertex-data": "^1.0.2",
     "object-assign": "^4.1.1",
     "pick-by-alias": "^1.2.0",
-    "to-float32": "^1.0.1",
+    "to-float32": "^1.1.0",
     "update-diff": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Upgrades to-float32 package and uses the new version to improve the performance when drawing.

You can see the to-float32 package changes [here](https://github.com/dy/to-float32/pull/1)

Other packages PRs: [here](https://github.com/gl-vis/regl-line2d/pull/50), [here](https://github.com/gl-vis/regl-scatter2d/pull/31)

@archmoj

cc: @alexcjohnson 